### PR TITLE
Solving Naming convention issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ pip install ecom_label_sorter
 
 ## Usage
 ```
-from label_sorter import Label_sorter
+from label_sorter import LabelSorter
 
 # Initialize
 sorter_instance = LabelSorter(pdf_path = <path to the pdf file>)
 
 # begin sorting
-sorter_instance.created_sorted_pdf_files()
+sorter_instance.create_sorted_pdf_files()
 
 # a new folder named after the input pdf file will be created and the output files will be stored inside it.
 ```

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 3. Miscellaneous orders will be stored on a dedicated file named "Mixed".
 4. All of these files will be stored inside a folder which is named after the input pdf file.
 
-
 ## Installation
 ```
 pip install ecom_label_sorter


### PR DESCRIPTION
There was mistakes regarding installation and running documentation.

## Summary by Sourcery

Fix naming conventions in README usage documentation

Documentation:
- Correct import statement to use LabelSorter class in README
- Update method name to create_sorted_pdf_files in README usage example